### PR TITLE
- Updated `.once` and added `.oneshot` modifier descriptions in the modifiers documentation.

### DIFF
--- a/docs/content/2.usage/3.modifiers.md
+++ b/docs/content/2.usage/3.modifiers.md
@@ -36,7 +36,7 @@ Makes the animation play only once when scrolling down, and stay in its final st
 Similar to `.once` but will reverse the animation when scrolling back up, allowing it to play again when scrolling down.
 
 ::alert{type="info"}
-Using `.once.reversible` gives you the previous behavior of `.once` from v1.1.8 and earlier.
+This is the default previous behavior of `.once`.
 ::
 
 

--- a/docs/content/2.usage/3.modifiers.md
+++ b/docs/content/2.usage/3.modifiers.md
@@ -39,13 +39,6 @@ Similar to `.once` but will reverse the animation when scrolling back up, allowi
 Using `.once.reversible` gives you the previous behavior of `.once` from v1.1.8 and earlier.
 ::
 
-### `.oneshot`
-
-Similar to `.once` but the animation will play only once and stay in its final state, never reversing.
-
-::alert{type="info"}
-Using both `.once` and `.oneshot` together will default to `.oneshot` behavior and show a warning.
-::
 
 ### `.markers`
 

--- a/docs/content/2.usage/3.modifiers.md
+++ b/docs/content/2.usage/3.modifiers.md
@@ -29,7 +29,15 @@ V-GSAP supports the above four main animation types.
 
 ### `.once`
 
-Allows the scrollTrigger to run only once, but will reverse when scrolling back up.
+Makes the animation play only once when scrolling down, and stay in its final state even when scrolling back up.
+
+### `.once.reversible`
+
+Similar to `.once` but will reverse the animation when scrolling back up, allowing it to play again when scrolling down.
+
+::alert{type="info"}
+Using `.once.reversible` gives you the previous behavior of `.once` from v1.1.8 and earlier.
+::
 
 ### `.oneshot`
 

--- a/docs/content/2.usage/3.modifiers.md
+++ b/docs/content/2.usage/3.modifiers.md
@@ -29,7 +29,15 @@ V-GSAP supports the above four main animation types.
 
 ### `.once`
 
-allows to run the scrollTrigger only once
+Allows the scrollTrigger to run only once, but will reverse when scrolling back up.
+
+### `.oneshot`
+
+Similar to `.once` but the animation will play only once and stay in its final state, never reversing.
+
+::alert{type="info"}
+Using both `.once` and `.oneshot` together will default to `.oneshot` behavior and show a warning.
+::
 
 ### `.markers`
 

--- a/docs/pages/playground.vue
+++ b/docs/pages/playground.vue
@@ -3,7 +3,10 @@
     <h1>Playground</h1>
 
     <section>
-      <div id="realworld" class="header">
+      <div
+        id="realworld"
+        class="header"
+      >
         <h2>Real world examples</h2>
       </div>
       <div class="Grid !grid-cols-1 lg:!grid-cols-2">
@@ -11,183 +14,357 @@
           <DemoParallax />
         </BoxComponent>
 
-        <Snippet name="DemoParallax" class="w-full" />
+        <Snippet
+          name="DemoParallax"
+          class="w-full"
+        />
       </div>
       <div class="Grid !grid-cols-1 lg:!grid-cols-2 mt-20">
         <BoxComponent class="w-full">
           <DemoCard />
         </BoxComponent>
-        <Snippet name="DemoCard" class="w-full" />
+        <Snippet
+          name="DemoCard"
+          class="w-full"
+        />
       </div>
       <div class="Grid !grid-cols-1 lg:!grid-cols-2 mt-20">
         <BoxComponent class="w-full">
           <DemoTextflow />
         </BoxComponent>
         <div>
-          <Snippet name="DemoTextflow" class="w-full" />
+          <Snippet
+            name="DemoTextflow"
+            class="w-full"
+          />
           <div class="my-4">
             Or with timeline:
           </div>
-          <Snippet name="DemoTextflowTimeline" class="w-full" />
+          <Snippet
+            name="DemoTextflowTimeline"
+            class="w-full"
+          />
         </div>
       </div>
-      <div v-gsap.timeline.pinned="{ end: '+=1500px' }" class="Grid !grid-cols-1 lg:!grid-cols-2 mt-20">
+      <div
+        v-gsap.timeline.pinned="{ end: '+=1500px' }"
+        class="Grid !grid-cols-1 lg:!grid-cols-2 mt-20"
+      >
         <DemoPinned />
-        <Snippet name="DemoPinned" class="w-full" />
+        <Snippet
+          name="DemoPinned"
+          class="w-full"
+        />
       </div>
     </section>
 
     <section>
-      <div id="parallax" class="header">
+      <div
+        id="parallax"
+        class="header"
+      >
         <h2>
           <pre>.parallax</pre>
         </h2>
-        <NuxtLink to="/usage/modifiers#parallax" target="_blank">
+        <NuxtLink
+          to="/usage/modifiers#parallax"
+          target="_blank"
+        >
           See reference
         </NuxtLink>
       </div>
       <div class="Grid">
-        <BoxComponent code="v-gsap.parallax.slower" title=".slower">
+        <BoxComponent
+          code="v-gsap.parallax.slower"
+          title=".slower"
+        >
           <DemoComponent v-gsap.parallax.slower />
         </BoxComponent>
-        <BoxComponent code="v-gsap.parallax.faster" title=".faster">
+        <BoxComponent
+          code="v-gsap.parallax.faster"
+          title=".faster"
+        >
           <DemoComponent v-gsap.parallax.faster />
         </BoxComponent>
-        <BoxComponent code="v-gsap.parallax.slower-10" title=".slower-10">
+        <BoxComponent
+          code="v-gsap.parallax.slower-10"
+          title=".slower-10"
+        >
           <DemoComponent v-gsap.parallax.slower-10 />
         </BoxComponent>
-        <BoxComponent code="v-gsap.parallax.slower-20" title=".slower-20">
+        <BoxComponent
+          code="v-gsap.parallax.slower-20"
+          title=".slower-20"
+        >
           <DemoComponent v-gsap.parallax.slower-20 />
         </BoxComponent>
-        <BoxComponent code="v-gsap.parallax.faster-10" title=".faster-10">
+        <BoxComponent
+          code="v-gsap.parallax.faster-10"
+          title=".faster-10"
+        >
           <DemoComponent v-gsap.parallax.faster-10 />
         </BoxComponent>
-        <BoxComponent code="v-gsap.parallax.faster-20" title=".faster-20">
+        <BoxComponent
+          code="v-gsap.parallax.faster-20"
+          title=".faster-20"
+        >
           <DemoComponent v-gsap.parallax.faster-20 />
         </BoxComponent>
       </div>
     </section>
 
     <section>
-      <div id="magnetic" class="header">
+      <div
+        id="magnetic"
+        class="header"
+      >
         <h2>
           <pre>.magnetic</pre>
         </h2>
-        <NuxtLink to="/usage/modifiers#magnetic" target="_blank">
+        <NuxtLink
+          to="/usage/modifiers#magnetic"
+          target="_blank"
+        >
           See reference
         </NuxtLink>
       </div>
       <div class="Grid">
-        <BoxComponent code="v-gsap.magnetic" title="Default">
-          <DemoComponent v-gsap.magnetic text="Hover me" />
+        <BoxComponent
+          code="v-gsap.magnetic"
+          title="Default"
+        >
+          <DemoComponent
+            v-gsap.magnetic
+            text="Hover me"
+          />
         </BoxComponent>
-        <BoxComponent code="v-gsap.magnetic.weak" title=".weak">
-          <DemoComponent v-gsap.magnetic.weak text="Hover me" />
+        <BoxComponent
+          code="v-gsap.magnetic.weak"
+          title=".weak"
+        >
+          <DemoComponent
+            v-gsap.magnetic.weak
+            text="Hover me"
+          />
         </BoxComponent>
-        <BoxComponent code="v-gsap.magnetic.weaker" title=".weaker">
-          <DemoComponent v-gsap.magnetic.weaker text="Hover me" />
+        <BoxComponent
+          code="v-gsap.magnetic.weaker"
+          title=".weaker"
+        >
+          <DemoComponent
+            v-gsap.magnetic.weaker
+            text="Hover me"
+          />
         </BoxComponent>
-        <BoxComponent code="v-gsap.magnetic.stronger" title=".stronger">
-          <DemoComponent v-gsap.magnetic.stronger text="Hover me" />
+        <BoxComponent
+          code="v-gsap.magnetic.stronger"
+          title=".stronger"
+        >
+          <DemoComponent
+            v-gsap.magnetic.stronger
+            text="Hover me"
+          />
         </BoxComponent>
-        <BoxComponent code="v-gsap.magnetic.strong" title=".strong">
-          <DemoComponent v-gsap.magnetic.strong text="Hover me" />
+        <BoxComponent
+          code="v-gsap.magnetic.strong"
+          title=".strong"
+        >
+          <DemoComponent
+            v-gsap.magnetic.strong
+            text="Hover me"
+          />
         </BoxComponent>
-        <BoxComponent code="v-gsap.magnetic.refuse" title=".refuse (lol)">
-          <DemoComponent v-gsap.magnetic.refuse text="Try me" />
+        <BoxComponent
+          code="v-gsap.magnetic.refuse"
+          title=".refuse (lol)"
+        >
+          <DemoComponent
+            v-gsap.magnetic.refuse
+            text="Try me"
+          />
         </BoxComponent>
       </div>
     </section>
 
     <section>
-      <div id="whenvisible" class="header">
+      <div
+        id="whenvisible"
+        class="header"
+      >
         <h2>
           <pre>.whenVisible</pre>
         </h2>
-        <NuxtLink to="/usage/modifiers#whenVisible" target="_blank">
+        <NuxtLink
+          to="/usage/modifiers#whenVisible"
+          target="_blank"
+        >
           See reference
         </NuxtLink>
       </div>
       <div class="Grid">
-        <BoxComponent code="v-gsap.whenVisible.from='{ autoAlpha: 0 }'" title="Fade">
+        <BoxComponent
+          code="v-gsap.whenVisible.from='{ autoAlpha: 0 }'"
+          title="Fade"
+        >
           <DemoComponent v-gsap.whenVisible.from="{ autoAlpha: 0 }" />
         </BoxComponent>
-        <BoxComponent code="v-gsap.whenVisible.from='{ autoAlpha: 0, rotate: '-45deg' }'" title="Fade Rotate">
-          <DemoComponent v-gsap.whenVisible.from="{ autoAlpha: 0, rotate: '-45deg' }" />
+        <BoxComponent
+          code="v-gsap.whenVisible.from='{ autoAlpha: 0, rotate: '-45deg' }'"
+          title="Fade Rotate"
+        >
+          <DemoComponent
+            v-gsap.whenVisible.from="{ autoAlpha: 0, rotate: '-45deg' }"
+          />
         </BoxComponent>
-        <BoxComponent code="v-gsap.whenVisible.from='{ autoAlpha: 0, rotate: '-45deg' }'" title="Fade Rotate (once)">
-          <DemoComponent v-gsap.whenVisible.once.from="{
-            autoAlpha: 0,
-            rotate: '-45deg',
-          }" />
+        <BoxComponent
+          code="v-gsap.whenVisible.from='{ autoAlpha: 0, rotate: '-45deg' }'"
+          title="Fade Rotate (once)"
+        >
+          <DemoComponent
+            v-gsap.whenVisible.once.from="{
+              autoAlpha: 0,
+              rotate: '-45deg',
+            }"
+          />
         </BoxComponent>
-        <BoxComponent code="v-gsap.whenVisible.from='{ autoAlpha: 0, x: -50 }'" title="Fade from left">
+        <BoxComponent
+          code="v-gsap.whenVisible.from='{ autoAlpha: 0, x: -50 }'"
+          title="Fade from left"
+        >
           <DemoComponent v-gsap.whenVisible.from="{ autoAlpha: 0, x: -50 }" />
         </BoxComponent>
-        <BoxComponent code="v-gsap.whenVisible.from='{ autoAlpha: 0, start: 'top 60%', end: 'bottom 40%' }'"
-          title="Custom start/end">
-          <DemoComponent v-gsap.whenVisible.from="{
-            autoAlpha: 0,
-            start: 'top 60%',
-            end: 'bottom 40%',
-          }" />
+        <BoxComponent
+          code="v-gsap.whenVisible.once.from='{ autoAlpha: 0, rotate: -45, duration: 2 }'"
+          title="Once (stays in final state)"
+        >
+          <DemoComponent
+            v-gsap.whenVisible.once.from="{
+              autoAlpha: 0,
+              rotate: -45,
+              duration: 2
+            }"
+          />
         </BoxComponent>
-        <BoxComponent code="v-gsap.whenVisible.oneshot.from='{ autoAlpha: 0, rotate: '-45deg' }'"
-          title="Fade Rotate (oneshot)">
-          <DemoComponent v-gsap.whenVisible.oneshot.from="{
-            autoAlpha: 0,
-            rotate: '-45deg',
-          }" />
+        <BoxComponent
+          code="v-gsap.whenVisible.once.reversible.from='{ autoAlpha: 0, rotate: -45, duration: 2 }'"
+          title="Once Reversible (old behavior)"
+        >
+          <DemoComponent
+            v-gsap.whenVisible.once.reversible.from="{
+              autoAlpha: 0,
+              rotate: -45,
+              duration: 2
+            }"
+          />
+        </BoxComponent>
+        <BoxComponent
+          code="v-gsap.whenVisible.from='{ autoAlpha: 0, start: 'top 60%', end: 'bottom 40%' }'"
+          title="Custom start/end"
+        >
+          <DemoComponent
+            v-gsap.whenVisible.from="{
+              autoAlpha: 0,
+              start: 'top 60%',
+              end: 'bottom 40%',
+            }"
+          />
         </BoxComponent>
       </div>
     </section>
 
     <section>
-      <div id="animatetext" class="header">
+      <div
+        id="animatetext"
+        class="header"
+      >
         <h2>
           <pre>.animateText</pre>
         </h2>
-        <NuxtLink to="/usage/modifiers#animatetext" target="_blank">
+        <NuxtLink
+          to="/usage/modifiers#animatetext"
+          target="_blank"
+        >
           See reference
         </NuxtLink>
       </div>
       <div class="Grid">
-        <BoxComponent code="v-gsap.whenVisible.animateText" title="Default">
-          <DemoComponent v-gsap.whenVisible.animateText="'Lorem ipsum dolor sit amed'" />
+        <BoxComponent
+          code="v-gsap.whenVisible.animateText"
+          title="Default"
+        >
+          <DemoComponent
+            v-gsap.whenVisible.animateText="'Lorem ipsum dolor sit amed'"
+          />
         </BoxComponent>
 
-        <BoxComponent code="v-gsap.whenVisible.animateText.slow" title=".slow">
-          <DemoComponent v-gsap.whenVisible.animateText.slow="'Lorem ipsum dolor sit amed'" />
+        <BoxComponent
+          code="v-gsap.whenVisible.animateText.slow"
+          title=".slow"
+        >
+          <DemoComponent
+            v-gsap.whenVisible.animateText.slow="'Lorem ipsum dolor sit amed'"
+          />
         </BoxComponent>
-        <BoxComponent code="v-gsap.whenVisible.animateText.fast" title=".fast">
-          <DemoComponent v-gsap.whenVisible.animateText.fast="'Lorem ipsum dolor sit amed'" />
+        <BoxComponent
+          code="v-gsap.whenVisible.animateText.fast"
+          title=".fast"
+        >
+          <DemoComponent
+            v-gsap.whenVisible.animateText.fast="'Lorem ipsum dolor sit amed'"
+          />
         </BoxComponent>
-        <BoxComponent code="v-gsap.whenVisible.once.animateText" title=".once">
-          <DemoComponent v-gsap.whenVisible.once.animateText="'Lorem ipsum dolor sit amed'" />
+        <BoxComponent
+          code="v-gsap.whenVisible.once.animateText"
+          title=".once"
+        >
+          <DemoComponent
+            v-gsap.whenVisible.once.animateText="'Lorem ipsum dolor sit amed'"
+          />
         </BoxComponent>
-        <BoxComponent code="v-gsap.whenVisible.animateText.once.slow" title=".once.slow">
-          <DemoComponent v-gsap.whenVisible.animateText.once.slow="'Lorem ipsum dolor sit amed'
-            " />
+        <BoxComponent
+          code="v-gsap.whenVisible.animateText.once.slow"
+          title=".once.slow"
+        >
+          <DemoComponent
+            v-gsap.whenVisible.animateText.once.slow="
+              'Lorem ipsum dolor sit amed'
+            "
+          />
         </BoxComponent>
-        <BoxComponent code="v-gsap.whenVisible.animateText.once.fast" title=".once.fast">
-          <DemoComponent v-gsap.whenVisible.animateText.once.fast="'Lorem ipsum dolor sit amed'
-            " />
+        <BoxComponent
+          code="v-gsap.whenVisible.animateText.once.fast"
+          title=".once.fast"
+        >
+          <DemoComponent
+            v-gsap.whenVisible.animateText.once.fast="
+              'Lorem ipsum dolor sit amed'
+            "
+          />
         </BoxComponent>
       </div>
     </section>
 
     <section>
-      <div id="stagger" class="header">
+      <div
+        id="stagger"
+        class="header"
+      >
         <h2>
           <pre>.stagger</pre>
         </h2>
-        <NuxtLink to="/usage/modifiers#stagger" target="_blank">
+        <NuxtLink
+          to="/usage/modifiers#stagger"
+          target="_blank"
+        >
           See reference
         </NuxtLink>
       </div>
       <div class="Grid">
-        <BoxComponent v-gsap.whenVisible.stagger.from="{ opacity: 0 }"
-          code="v-gsap.whenVisible.stagger.from='{ opacity: 0 }'" title="Default">
+        <BoxComponent
+          v-gsap.whenVisible.stagger.from="{ opacity: 0, y: 50, stagger: 0.4 }"
+          code="v-gsap.whenVisible.stagger.from='{ opacity: 0, y: 50, stagger: 0.4 }'"
+          title="Default"
+        >
           <DemoComponent />
           <DemoComponent />
           <DemoComponent />
@@ -196,63 +373,103 @@
     </section>
 
     <section>
-      <div id="whilehover" class="header">
+      <div
+        id="whilehover"
+        class="header"
+      >
         <h2>
           <pre>.whileHover</pre>
         </h2>
-        <NuxtLink to="/usage/modifiers#whilehover" target="_blank">
+        <NuxtLink
+          to="/usage/modifiers#whilehover"
+          target="_blank"
+        >
           See reference
         </NuxtLink>
       </div>
       <div class="Grid">
-        <BoxComponent code="v-gsap.whileHover.to='{ rotate: '-15deg', y: -12 }'" title="Default">
+        <BoxComponent
+          code="v-gsap.whileHover.to='{ rotate: '-15deg', y: -12 }'"
+          title="Default"
+        >
           <DemoComponent v-gsap.whileHover.to="{ rotate: '-15deg', y: -12 }" />
         </BoxComponent>
-        <BoxComponent code="v-gsap.whileHover.noReverse.to='{ rotate: '-15deg', y: -12 }'" title=".noReverse">
-          <DemoComponent v-gsap.whileHover.noReverse.to="{ rotate: '-15deg', y: -12 }" />
+        <BoxComponent
+          code="v-gsap.whileHover.noReverse.to='{ rotate: '-15deg', y: -12 }'"
+          title=".noReverse"
+        >
+          <DemoComponent
+            v-gsap.whileHover.noReverse.to="{ rotate: '-15deg', y: -12 }"
+          />
         </BoxComponent>
       </div>
     </section>
 
     <section>
-      <div id="delay" class="header">
+      <div
+        id="delay"
+        class="header"
+      >
         <h2>
           <pre>.delay-</pre>
         </h2>
-        <NuxtLink to="/usage/modifiers#delay-milliseconds" target="_blank">
+        <NuxtLink
+          to="/usage/modifiers#delay-milliseconds"
+          target="_blank"
+        >
           See reference
         </NuxtLink>
       </div>
       <div class="Grid">
-        <BoxComponent code="v-gsap.whileHover.delay-500.to='{ rotate: '-15deg', y: -12 }'" title=".delay-500">
+        <BoxComponent
+          code="v-gsap.whileHover.delay-500.to='{ rotate: '-15deg', y: -12 }'"
+          title=".delay-500"
+        >
           <DemoComponent v-gsap.whileHover.delay-500.to="{ scale: 1.2 }" />
         </BoxComponent>
-        <BoxComponent code="v-gsap.whileHover.delay-789.to='{ rotate: '-15deg', y: -12 }'" title=".delay-789">
+        <BoxComponent
+          code="v-gsap.whileHover.delay-789.to='{ rotate: '-15deg', y: -12 }'"
+          title=".delay-789"
+        >
           <DemoComponent v-gsap.whileHover.delay-789.to="{ scale: 1.2 }" />
         </BoxComponent>
 
-        <BoxComponent code="v-gsap.whenVisible.once.delay-1000.to='{ x: 100 }'" title="delay after visible">
+        <BoxComponent
+          code="v-gsap.whenVisible.once.delay-1000.to='{ x: 100 }'"
+          title="delay after visible"
+        >
           <DemoComponent v-gsap.whenVisible.once.delay-1000.to="{ x: 100 }" />
         </BoxComponent>
       </div>
     </section>
 
     <section>
-      <div id="infinitely" class="header">
+      <div
+        id="infinitely"
+        class="header"
+      >
         <h2>
           <pre>.infinitely</pre>
         </h2>
-        <NuxtLink to="/usage/modifiers#infinitely" target="_blank">
+        <NuxtLink
+          to="/usage/modifiers#infinitely"
+          target="_blank"
+        >
           See reference
         </NuxtLink>
       </div>
       <div class="Grid">
-        <BoxComponent code="v-gsap.whileHover.to='{ rotate: '-15deg', y: -12 }'" title="Default">
-          <DemoComponent v-gsap.infinitely.to="{
-            rotate: '360deg',
-            ease: 'linear',
-            duration: 10,
-          }" />
+        <BoxComponent
+          code="v-gsap.whileHover.to='{ rotate: '-15deg', y: -12 }'"
+          title="Default"
+        >
+          <DemoComponent
+            v-gsap.infinitely.to="{
+              rotate: '360deg',
+              ease: 'linear',
+              duration: 10,
+            }"
+          />
         </BoxComponent>
       </div>
     </section>
@@ -262,68 +479,112 @@
         <h2>
           <pre>.draggable</pre>
         </h2>
-        <NuxtLink to="/usage/modifiers#draggable" target="_blank">
+        <NuxtLink
+          to="/usage/modifiers#draggable"
+          target="_blank"
+        >
           See reference
         </NuxtLink>
       </div>
       <div class="Grid">
-        <BoxComponent code="v-gsap.draggable" title="Default">
+        <BoxComponent
+          code="v-gsap.draggable"
+          title="Default"
+        >
           <DemoComponent v-gsap.draggable />
         </BoxComponent>
-        <BoxComponent code="v-gsap.draggable.x" title=".x">
+        <BoxComponent
+          code="v-gsap.draggable.x"
+          title=".x"
+        >
           <DemoComponent v-gsap.draggable.x />
         </BoxComponent>
-        <BoxComponent code="v-gsap.draggable.y" title=".y">
+        <BoxComponent
+          code="v-gsap.draggable.y"
+          title=".y"
+        >
           <DemoComponent v-gsap.draggable.y />
         </BoxComponent>
-        <BoxComponent code="v-gsap.draggable.rotation" title=".rotation">
+        <BoxComponent
+          code="v-gsap.draggable.rotation"
+          title=".rotation"
+        >
           <DemoComponent v-gsap.draggable.rotation />
         </BoxComponent>
-        <BoxComponent code="v-gsap.draggable.bounds='#draggable'" title=".bounds (selector)" overflow="visible">
+        <BoxComponent
+          code="v-gsap.draggable.bounds='#draggable'"
+          title=".bounds (selector)"
+          overflow="visible"
+        >
           <DemoComponent v-gsap.draggable.bounds="'#draggable'" />
         </BoxComponent>
       </div>
     </section>
 
     <section>
-      <div id="desktop" class="header">
+      <div
+        id="desktop"
+        class="header"
+      >
         <h2 class="!flex items-center gap-2">
           <pre>.desktop</pre>
           <pre>.mobile</pre>
         </h2>
-        <NuxtLink to="/usage/modifiers#desktop" target="_blank">
+        <NuxtLink
+          to="/usage/modifiers#desktop"
+          target="_blank"
+        >
           See reference
         </NuxtLink>
       </div>
       <div class="Grid">
-        <BoxComponent code="v-gsap.desktop.infinitely.to" title="Desktop only">
-          <DemoComponent v-gsap.desktop.infinitely.to="{
-            rotate: '360deg',
-            ease: 'linear',
-            duration: 10,
-          }" />
+        <BoxComponent
+          code="v-gsap.desktop.infinitely.to"
+          title="Desktop only"
+        >
+          <DemoComponent
+            v-gsap.desktop.infinitely.to="{
+              rotate: '360deg',
+              ease: 'linear',
+              duration: 10,
+            }"
+          />
         </BoxComponent>
-        <BoxComponent code="v-gsap.mobile.infinitely.to" title="Mobile only">
-          <DemoComponent v-gsap.mobile.infinitely.to="{
-            rotate: '360deg',
-            ease: 'linear',
-            duration: 10,
-          }" />
+        <BoxComponent
+          code="v-gsap.mobile.infinitely.to"
+          title="Mobile only"
+        >
+          <DemoComponent
+            v-gsap.mobile.infinitely.to="{
+              rotate: '360deg',
+              ease: 'linear',
+              duration: 10,
+            }"
+          />
         </BoxComponent>
       </div>
     </section>
 
     <section>
-      <div id="preset" class="header">
+      <div
+        id="preset"
+        class="header"
+      >
         <h2>
           <pre>.preset</pre>
         </h2>
-        <NuxtLink to="/usage/modifiers#preset" target="_blank">
+        <NuxtLink
+          to="/usage/modifiers#preset"
+          target="_blank"
+        >
           See reference
         </NuxtLink>
       </div>
       <div class="Grid">
-        <BoxComponent code="v-gsap.preset='rotate'" title="Preset 'rotate' from nuxt.config">
+        <BoxComponent
+          code="v-gsap.preset='rotate'"
+          title="Preset 'rotate' from nuxt.config"
+        >
           <DemoComponent v-gsap.preset="'rotate'" />
         </BoxComponent>
       </div>
@@ -376,7 +637,7 @@ section {
   @apply my-8;
 
   div.header {
-    @apply w-full flex flex-col items-start justify-start md:flex-row md:items-end gap-6;
+    @apply w-full flex flex-col items-start justify-start md:flex-row md:items-end  gap-6;
     @apply my-12;
 
     h2 {
@@ -388,7 +649,7 @@ section {
     }
 
     pre {
-      @apply py-1 px-3 bg-black/5 text-gray-700 rounded-lg;
+      @apply py-1 px-3 bg-black/5 text-gray-700  rounded-lg;
       @apply dark:text-white dark:bg-white/10;
     }
   }

--- a/docs/pages/playground.vue
+++ b/docs/pages/playground.vue
@@ -3,10 +3,7 @@
     <h1>Playground</h1>
 
     <section>
-      <div
-        id="realworld"
-        class="header"
-      >
+      <div id="realworld" class="header">
         <h2>Real world examples</h2>
       </div>
       <div class="Grid !grid-cols-1 lg:!grid-cols-2">
@@ -14,333 +11,183 @@
           <DemoParallax />
         </BoxComponent>
 
-        <Snippet
-          name="DemoParallax"
-          class="w-full"
-        />
+        <Snippet name="DemoParallax" class="w-full" />
       </div>
       <div class="Grid !grid-cols-1 lg:!grid-cols-2 mt-20">
         <BoxComponent class="w-full">
           <DemoCard />
         </BoxComponent>
-        <Snippet
-          name="DemoCard"
-          class="w-full"
-        />
+        <Snippet name="DemoCard" class="w-full" />
       </div>
       <div class="Grid !grid-cols-1 lg:!grid-cols-2 mt-20">
         <BoxComponent class="w-full">
           <DemoTextflow />
         </BoxComponent>
         <div>
-          <Snippet
-            name="DemoTextflow"
-            class="w-full"
-          />
+          <Snippet name="DemoTextflow" class="w-full" />
           <div class="my-4">
             Or with timeline:
           </div>
-          <Snippet
-            name="DemoTextflowTimeline"
-            class="w-full"
-          />
+          <Snippet name="DemoTextflowTimeline" class="w-full" />
         </div>
       </div>
-      <div
-        v-gsap.timeline.pinned="{ end: '+=1500px' }"
-        class="Grid !grid-cols-1 lg:!grid-cols-2 mt-20"
-      >
+      <div v-gsap.timeline.pinned="{ end: '+=1500px' }" class="Grid !grid-cols-1 lg:!grid-cols-2 mt-20">
         <DemoPinned />
-        <Snippet
-          name="DemoPinned"
-          class="w-full"
-        />
+        <Snippet name="DemoPinned" class="w-full" />
       </div>
     </section>
 
     <section>
-      <div
-        id="parallax"
-        class="header"
-      >
+      <div id="parallax" class="header">
         <h2>
           <pre>.parallax</pre>
         </h2>
-        <NuxtLink
-          to="/usage/modifiers#parallax"
-          target="_blank"
-        >
+        <NuxtLink to="/usage/modifiers#parallax" target="_blank">
           See reference
         </NuxtLink>
       </div>
       <div class="Grid">
-        <BoxComponent
-          code="v-gsap.parallax.slower"
-          title=".slower"
-        >
+        <BoxComponent code="v-gsap.parallax.slower" title=".slower">
           <DemoComponent v-gsap.parallax.slower />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.parallax.faster"
-          title=".faster"
-        >
+        <BoxComponent code="v-gsap.parallax.faster" title=".faster">
           <DemoComponent v-gsap.parallax.faster />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.parallax.slower-10"
-          title=".slower-10"
-        >
+        <BoxComponent code="v-gsap.parallax.slower-10" title=".slower-10">
           <DemoComponent v-gsap.parallax.slower-10 />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.parallax.slower-20"
-          title=".slower-20"
-        >
+        <BoxComponent code="v-gsap.parallax.slower-20" title=".slower-20">
           <DemoComponent v-gsap.parallax.slower-20 />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.parallax.faster-10"
-          title=".faster-10"
-        >
+        <BoxComponent code="v-gsap.parallax.faster-10" title=".faster-10">
           <DemoComponent v-gsap.parallax.faster-10 />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.parallax.faster-20"
-          title=".faster-20"
-        >
+        <BoxComponent code="v-gsap.parallax.faster-20" title=".faster-20">
           <DemoComponent v-gsap.parallax.faster-20 />
         </BoxComponent>
       </div>
     </section>
 
     <section>
-      <div
-        id="magnetic"
-        class="header"
-      >
+      <div id="magnetic" class="header">
         <h2>
           <pre>.magnetic</pre>
         </h2>
-        <NuxtLink
-          to="/usage/modifiers#magnetic"
-          target="_blank"
-        >
+        <NuxtLink to="/usage/modifiers#magnetic" target="_blank">
           See reference
         </NuxtLink>
       </div>
       <div class="Grid">
-        <BoxComponent
-          code="v-gsap.magnetic"
-          title="Default"
-        >
-          <DemoComponent
-            v-gsap.magnetic
-            text="Hover me"
-          />
+        <BoxComponent code="v-gsap.magnetic" title="Default">
+          <DemoComponent v-gsap.magnetic text="Hover me" />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.magnetic.weak"
-          title=".weak"
-        >
-          <DemoComponent
-            v-gsap.magnetic.weak
-            text="Hover me"
-          />
+        <BoxComponent code="v-gsap.magnetic.weak" title=".weak">
+          <DemoComponent v-gsap.magnetic.weak text="Hover me" />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.magnetic.weaker"
-          title=".weaker"
-        >
-          <DemoComponent
-            v-gsap.magnetic.weaker
-            text="Hover me"
-          />
+        <BoxComponent code="v-gsap.magnetic.weaker" title=".weaker">
+          <DemoComponent v-gsap.magnetic.weaker text="Hover me" />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.magnetic.stronger"
-          title=".stronger"
-        >
-          <DemoComponent
-            v-gsap.magnetic.stronger
-            text="Hover me"
-          />
+        <BoxComponent code="v-gsap.magnetic.stronger" title=".stronger">
+          <DemoComponent v-gsap.magnetic.stronger text="Hover me" />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.magnetic.strong"
-          title=".strong"
-        >
-          <DemoComponent
-            v-gsap.magnetic.strong
-            text="Hover me"
-          />
+        <BoxComponent code="v-gsap.magnetic.strong" title=".strong">
+          <DemoComponent v-gsap.magnetic.strong text="Hover me" />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.magnetic.refuse"
-          title=".refuse (lol)"
-        >
-          <DemoComponent
-            v-gsap.magnetic.refuse
-            text="Try me"
-          />
+        <BoxComponent code="v-gsap.magnetic.refuse" title=".refuse (lol)">
+          <DemoComponent v-gsap.magnetic.refuse text="Try me" />
         </BoxComponent>
       </div>
     </section>
 
     <section>
-      <div
-        id="whenvisible"
-        class="header"
-      >
+      <div id="whenvisible" class="header">
         <h2>
           <pre>.whenVisible</pre>
         </h2>
-        <NuxtLink
-          to="/usage/modifiers#whenVisible"
-          target="_blank"
-        >
+        <NuxtLink to="/usage/modifiers#whenVisible" target="_blank">
           See reference
         </NuxtLink>
       </div>
       <div class="Grid">
-        <BoxComponent
-          code="v-gsap.whenVisible.from='{ autoAlpha: 0 }'"
-          title="Fade"
-        >
+        <BoxComponent code="v-gsap.whenVisible.from='{ autoAlpha: 0 }'" title="Fade">
           <DemoComponent v-gsap.whenVisible.from="{ autoAlpha: 0 }" />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.whenVisible.from='{ autoAlpha: 0, rotate: '-45deg' }'"
-          title="Fade Rotate"
-        >
-          <DemoComponent
-            v-gsap.whenVisible.from="{ autoAlpha: 0, rotate: '-45deg' }"
-          />
+        <BoxComponent code="v-gsap.whenVisible.from='{ autoAlpha: 0, rotate: '-45deg' }'" title="Fade Rotate">
+          <DemoComponent v-gsap.whenVisible.from="{ autoAlpha: 0, rotate: '-45deg' }" />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.whenVisible.from='{ autoAlpha: 0, rotate: '-45deg' }'"
-          title="Fade Rotate (once)"
-        >
-          <DemoComponent
-            v-gsap.whenVisible.once.from="{
-              autoAlpha: 0,
-              rotate: '-45deg',
-            }"
-          />
+        <BoxComponent code="v-gsap.whenVisible.from='{ autoAlpha: 0, rotate: '-45deg' }'" title="Fade Rotate (once)">
+          <DemoComponent v-gsap.whenVisible.once.from="{
+            autoAlpha: 0,
+            rotate: '-45deg',
+          }" />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.whenVisible.from='{ autoAlpha: 0, x: -50 }'"
-          title="Fade from left"
-        >
+        <BoxComponent code="v-gsap.whenVisible.from='{ autoAlpha: 0, x: -50 }'" title="Fade from left">
           <DemoComponent v-gsap.whenVisible.from="{ autoAlpha: 0, x: -50 }" />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.whenVisible.from='{ autoAlpha: 0, start: 'top 60%', end: 'bottom 40%' }'"
-          title="Custom start/end"
-        >
-          <DemoComponent
-            v-gsap.whenVisible.from="{
-              autoAlpha: 0,
-              start: 'top 60%',
-              end: 'bottom 40%',
-            }"
-          />
+        <BoxComponent code="v-gsap.whenVisible.from='{ autoAlpha: 0, start: 'top 60%', end: 'bottom 40%' }'"
+          title="Custom start/end">
+          <DemoComponent v-gsap.whenVisible.from="{
+            autoAlpha: 0,
+            start: 'top 60%',
+            end: 'bottom 40%',
+          }" />
+        </BoxComponent>
+        <BoxComponent code="v-gsap.whenVisible.oneshot.from='{ autoAlpha: 0, rotate: '-45deg' }'"
+          title="Fade Rotate (oneshot)">
+          <DemoComponent v-gsap.whenVisible.oneshot.from="{
+            autoAlpha: 0,
+            rotate: '-45deg',
+          }" />
         </BoxComponent>
       </div>
     </section>
 
     <section>
-      <div
-        id="animatetext"
-        class="header"
-      >
+      <div id="animatetext" class="header">
         <h2>
           <pre>.animateText</pre>
         </h2>
-        <NuxtLink
-          to="/usage/modifiers#animatetext"
-          target="_blank"
-        >
+        <NuxtLink to="/usage/modifiers#animatetext" target="_blank">
           See reference
         </NuxtLink>
       </div>
       <div class="Grid">
-        <BoxComponent
-          code="v-gsap.whenVisible.animateText"
-          title="Default"
-        >
-          <DemoComponent
-            v-gsap.whenVisible.animateText="'Lorem ipsum dolor sit amed'"
-          />
+        <BoxComponent code="v-gsap.whenVisible.animateText" title="Default">
+          <DemoComponent v-gsap.whenVisible.animateText="'Lorem ipsum dolor sit amed'" />
         </BoxComponent>
 
-        <BoxComponent
-          code="v-gsap.whenVisible.animateText.slow"
-          title=".slow"
-        >
-          <DemoComponent
-            v-gsap.whenVisible.animateText.slow="'Lorem ipsum dolor sit amed'"
-          />
+        <BoxComponent code="v-gsap.whenVisible.animateText.slow" title=".slow">
+          <DemoComponent v-gsap.whenVisible.animateText.slow="'Lorem ipsum dolor sit amed'" />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.whenVisible.animateText.fast"
-          title=".fast"
-        >
-          <DemoComponent
-            v-gsap.whenVisible.animateText.fast="'Lorem ipsum dolor sit amed'"
-          />
+        <BoxComponent code="v-gsap.whenVisible.animateText.fast" title=".fast">
+          <DemoComponent v-gsap.whenVisible.animateText.fast="'Lorem ipsum dolor sit amed'" />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.whenVisible.once.animateText"
-          title=".once"
-        >
-          <DemoComponent
-            v-gsap.whenVisible.once.animateText="'Lorem ipsum dolor sit amed'"
-          />
+        <BoxComponent code="v-gsap.whenVisible.once.animateText" title=".once">
+          <DemoComponent v-gsap.whenVisible.once.animateText="'Lorem ipsum dolor sit amed'" />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.whenVisible.animateText.once.slow"
-          title=".once.slow"
-        >
-          <DemoComponent
-            v-gsap.whenVisible.animateText.once.slow="
-              'Lorem ipsum dolor sit amed'
-            "
-          />
+        <BoxComponent code="v-gsap.whenVisible.animateText.once.slow" title=".once.slow">
+          <DemoComponent v-gsap.whenVisible.animateText.once.slow="'Lorem ipsum dolor sit amed'
+            " />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.whenVisible.animateText.once.fast"
-          title=".once.fast"
-        >
-          <DemoComponent
-            v-gsap.whenVisible.animateText.once.fast="
-              'Lorem ipsum dolor sit amed'
-            "
-          />
+        <BoxComponent code="v-gsap.whenVisible.animateText.once.fast" title=".once.fast">
+          <DemoComponent v-gsap.whenVisible.animateText.once.fast="'Lorem ipsum dolor sit amed'
+            " />
         </BoxComponent>
       </div>
     </section>
 
     <section>
-      <div
-        id="stagger"
-        class="header"
-      >
+      <div id="stagger" class="header">
         <h2>
           <pre>.stagger</pre>
         </h2>
-        <NuxtLink
-          to="/usage/modifiers#stagger"
-          target="_blank"
-        >
+        <NuxtLink to="/usage/modifiers#stagger" target="_blank">
           See reference
         </NuxtLink>
       </div>
       <div class="Grid">
-        <BoxComponent
-          v-gsap.whenVisible.stagger.from="{ opacity: 0 }"
-          code="v-gsap.whenVisible.stagger.from='{ opacity: 0 }'"
-          title="Default"
-        >
+        <BoxComponent v-gsap.whenVisible.stagger.from="{ opacity: 0 }"
+          code="v-gsap.whenVisible.stagger.from='{ opacity: 0 }'" title="Default">
           <DemoComponent />
           <DemoComponent />
           <DemoComponent />
@@ -349,103 +196,63 @@
     </section>
 
     <section>
-      <div
-        id="whilehover"
-        class="header"
-      >
+      <div id="whilehover" class="header">
         <h2>
           <pre>.whileHover</pre>
         </h2>
-        <NuxtLink
-          to="/usage/modifiers#whilehover"
-          target="_blank"
-        >
+        <NuxtLink to="/usage/modifiers#whilehover" target="_blank">
           See reference
         </NuxtLink>
       </div>
       <div class="Grid">
-        <BoxComponent
-          code="v-gsap.whileHover.to='{ rotate: '-15deg', y: -12 }'"
-          title="Default"
-        >
+        <BoxComponent code="v-gsap.whileHover.to='{ rotate: '-15deg', y: -12 }'" title="Default">
           <DemoComponent v-gsap.whileHover.to="{ rotate: '-15deg', y: -12 }" />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.whileHover.noReverse.to='{ rotate: '-15deg', y: -12 }'"
-          title=".noReverse"
-        >
-          <DemoComponent
-            v-gsap.whileHover.noReverse.to="{ rotate: '-15deg', y: -12 }"
-          />
+        <BoxComponent code="v-gsap.whileHover.noReverse.to='{ rotate: '-15deg', y: -12 }'" title=".noReverse">
+          <DemoComponent v-gsap.whileHover.noReverse.to="{ rotate: '-15deg', y: -12 }" />
         </BoxComponent>
       </div>
     </section>
 
     <section>
-      <div
-        id="delay"
-        class="header"
-      >
+      <div id="delay" class="header">
         <h2>
           <pre>.delay-</pre>
         </h2>
-        <NuxtLink
-          to="/usage/modifiers#delay-milliseconds"
-          target="_blank"
-        >
+        <NuxtLink to="/usage/modifiers#delay-milliseconds" target="_blank">
           See reference
         </NuxtLink>
       </div>
       <div class="Grid">
-        <BoxComponent
-          code="v-gsap.whileHover.delay-500.to='{ rotate: '-15deg', y: -12 }'"
-          title=".delay-500"
-        >
+        <BoxComponent code="v-gsap.whileHover.delay-500.to='{ rotate: '-15deg', y: -12 }'" title=".delay-500">
           <DemoComponent v-gsap.whileHover.delay-500.to="{ scale: 1.2 }" />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.whileHover.delay-789.to='{ rotate: '-15deg', y: -12 }'"
-          title=".delay-789"
-        >
+        <BoxComponent code="v-gsap.whileHover.delay-789.to='{ rotate: '-15deg', y: -12 }'" title=".delay-789">
           <DemoComponent v-gsap.whileHover.delay-789.to="{ scale: 1.2 }" />
         </BoxComponent>
 
-        <BoxComponent
-          code="v-gsap.whenVisible.once.delay-1000.to='{ x: 100 }'"
-          title="delay after visible"
-        >
+        <BoxComponent code="v-gsap.whenVisible.once.delay-1000.to='{ x: 100 }'" title="delay after visible">
           <DemoComponent v-gsap.whenVisible.once.delay-1000.to="{ x: 100 }" />
         </BoxComponent>
       </div>
     </section>
 
     <section>
-      <div
-        id="infinitely"
-        class="header"
-      >
+      <div id="infinitely" class="header">
         <h2>
           <pre>.infinitely</pre>
         </h2>
-        <NuxtLink
-          to="/usage/modifiers#infinitely"
-          target="_blank"
-        >
+        <NuxtLink to="/usage/modifiers#infinitely" target="_blank">
           See reference
         </NuxtLink>
       </div>
       <div class="Grid">
-        <BoxComponent
-          code="v-gsap.whileHover.to='{ rotate: '-15deg', y: -12 }'"
-          title="Default"
-        >
-          <DemoComponent
-            v-gsap.infinitely.to="{
-              rotate: '360deg',
-              ease: 'linear',
-              duration: 10,
-            }"
-          />
+        <BoxComponent code="v-gsap.whileHover.to='{ rotate: '-15deg', y: -12 }'" title="Default">
+          <DemoComponent v-gsap.infinitely.to="{
+            rotate: '360deg',
+            ease: 'linear',
+            duration: 10,
+          }" />
         </BoxComponent>
       </div>
     </section>
@@ -455,112 +262,68 @@
         <h2>
           <pre>.draggable</pre>
         </h2>
-        <NuxtLink
-          to="/usage/modifiers#draggable"
-          target="_blank"
-        >
+        <NuxtLink to="/usage/modifiers#draggable" target="_blank">
           See reference
         </NuxtLink>
       </div>
       <div class="Grid">
-        <BoxComponent
-          code="v-gsap.draggable"
-          title="Default"
-        >
+        <BoxComponent code="v-gsap.draggable" title="Default">
           <DemoComponent v-gsap.draggable />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.draggable.x"
-          title=".x"
-        >
+        <BoxComponent code="v-gsap.draggable.x" title=".x">
           <DemoComponent v-gsap.draggable.x />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.draggable.y"
-          title=".y"
-        >
+        <BoxComponent code="v-gsap.draggable.y" title=".y">
           <DemoComponent v-gsap.draggable.y />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.draggable.rotation"
-          title=".rotation"
-        >
+        <BoxComponent code="v-gsap.draggable.rotation" title=".rotation">
           <DemoComponent v-gsap.draggable.rotation />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.draggable.bounds='#draggable'"
-          title=".bounds (selector)"
-          overflow="visible"
-        >
+        <BoxComponent code="v-gsap.draggable.bounds='#draggable'" title=".bounds (selector)" overflow="visible">
           <DemoComponent v-gsap.draggable.bounds="'#draggable'" />
         </BoxComponent>
       </div>
     </section>
 
     <section>
-      <div
-        id="desktop"
-        class="header"
-      >
+      <div id="desktop" class="header">
         <h2 class="!flex items-center gap-2">
           <pre>.desktop</pre>
           <pre>.mobile</pre>
         </h2>
-        <NuxtLink
-          to="/usage/modifiers#desktop"
-          target="_blank"
-        >
+        <NuxtLink to="/usage/modifiers#desktop" target="_blank">
           See reference
         </NuxtLink>
       </div>
       <div class="Grid">
-        <BoxComponent
-          code="v-gsap.desktop.infinitely.to"
-          title="Desktop only"
-        >
-          <DemoComponent
-            v-gsap.desktop.infinitely.to="{
-              rotate: '360deg',
-              ease: 'linear',
-              duration: 10,
-            }"
-          />
+        <BoxComponent code="v-gsap.desktop.infinitely.to" title="Desktop only">
+          <DemoComponent v-gsap.desktop.infinitely.to="{
+            rotate: '360deg',
+            ease: 'linear',
+            duration: 10,
+          }" />
         </BoxComponent>
-        <BoxComponent
-          code="v-gsap.mobile.infinitely.to"
-          title="Mobile only"
-        >
-          <DemoComponent
-            v-gsap.mobile.infinitely.to="{
-              rotate: '360deg',
-              ease: 'linear',
-              duration: 10,
-            }"
-          />
+        <BoxComponent code="v-gsap.mobile.infinitely.to" title="Mobile only">
+          <DemoComponent v-gsap.mobile.infinitely.to="{
+            rotate: '360deg',
+            ease: 'linear',
+            duration: 10,
+          }" />
         </BoxComponent>
       </div>
     </section>
 
     <section>
-      <div
-        id="preset"
-        class="header"
-      >
+      <div id="preset" class="header">
         <h2>
           <pre>.preset</pre>
         </h2>
-        <NuxtLink
-          to="/usage/modifiers#preset"
-          target="_blank"
-        >
+        <NuxtLink to="/usage/modifiers#preset" target="_blank">
           See reference
         </NuxtLink>
       </div>
       <div class="Grid">
-        <BoxComponent
-          code="v-gsap.preset='rotate'"
-          title="Preset 'rotate' from nuxt.config"
-        >
+        <BoxComponent code="v-gsap.preset='rotate'" title="Preset 'rotate' from nuxt.config">
           <DemoComponent v-gsap.preset="'rotate'" />
         </BoxComponent>
       </div>
@@ -613,7 +376,7 @@ section {
   @apply my-8;
 
   div.header {
-    @apply w-full flex flex-col items-start justify-start md:flex-row md:items-end  gap-6;
+    @apply w-full flex flex-col items-start justify-start md:flex-row md:items-end gap-6;
     @apply my-12;
 
     h2 {
@@ -625,7 +388,7 @@ section {
     }
 
     pre {
-      @apply py-1 px-3 bg-black/5 text-gray-700  rounded-lg;
+      @apply py-1 px-3 bg-black/5 text-gray-700 rounded-lg;
       @apply dark:text-white dark:bg-white/10;
     }
   }

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -50,7 +50,7 @@ export const vGsapDirective = (
 
   beforeMount(el, binding, vnode) {
     if (appType == 'vue') el.dataset.gsapId = uuidv4()
-    if (!gsapContext) gsapContext = gsap.context(() => {})
+    if (!gsapContext) gsapContext = gsap.context(() => { })
 
     binding = loadPreset(binding, configOptions)
 
@@ -133,39 +133,41 @@ function assignChildrenOrderAttributesFor(vnode, startOrder?): number {
     return []
   }
 
-  ;(getChildren(vnode) || [])?.forEach((child: any) => {
-    ;(child?.dirs ? Array.from(child?.dirs) : [])?.forEach((dir: any) => {
-      if (dir.modifiers.timeline) return
+    ; (getChildren(vnode) || [])?.forEach((child: any) => {
+      ; (child?.dirs ? Array.from(child?.dirs) : [])?.forEach((dir: any) => {
+        if (dir.modifiers.timeline) return
 
-      dir.modifiers[`suggestedOrder-${order}`] = true
-      order++
+        dir.modifiers[`suggestedOrder-${order}`] = true
+        order++
+      })
+      order = assignChildrenOrderAttributesFor(child, order)
     })
-    order = assignChildrenOrderAttributesFor(child, order)
-  })
   return order
 }
 
 function prepareTimeline(el, binding, configOptions) {
   const timelineOptions: TIMELINE_OPTIONS = {}
-
   const callbacks = prepareCallbacks(binding)
 
-  // Prepare ScrollTrigger if .whenVisible. modifier is present
-  // You can overwrite scrollTrigger Props in the value of the directive
-  // .once.
   const once = binding.modifiers.call ?? binding.modifiers.once
-  const scroller
-    = configOptions?.scroller
+  const oneshot = binding.modifiers.oneshot
+
+  // Prevent using both modifiers together
+  if (once && oneshot) {
+    console.warn('Cannot use .once and .oneshot together. Defaulting to .oneshot')
+  }
+
+  const scroller = configOptions?.scroller
     || binding.value?.scroller
     || binding.value?.[0]?.scroller
     || binding.value?.[1]?.scroller
     || undefined
-  const scrub
-    = binding.value?.scrub
+  const scrub = binding.value?.scrub
     ?? binding.value?.[1]?.scrub
-    ?? (once == true ? false : undefined)
+    ?? ((once || oneshot) ? false : undefined)
     ?? true
   const markers = binding.modifiers.markers
+
   if (binding.modifiers.whenVisible) {
     timelineOptions.scrollTrigger = {
       trigger: el,
@@ -175,7 +177,9 @@ function prepareTimeline(el, binding, configOptions) {
       scrub,
       ...callbacks,
       markers,
-      toggleActions: once ? 'play none none reverse' : undefined,
+      toggleActions: (once && !oneshot) ? 'play none none reverse'
+        : oneshot ? 'play none none none'
+          : undefined,
     }
   }
 
@@ -284,9 +288,9 @@ function prepareTimeline(el, binding, configOptions) {
     }
     const speed
       = speeds[
-        Object.keys(binding.modifiers).find(modifier =>
-          Object.keys(speeds).includes(modifier),
-        ) || ''
+      Object.keys(binding.modifiers).find(modifier =>
+        Object.keys(speeds).includes(modifier),
+      ) || ''
       ] || 2
     timeline.to(el, { text: { value, speed } })
   }

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -147,27 +147,25 @@ function assignChildrenOrderAttributesFor(vnode, startOrder?): number {
 
 function prepareTimeline(el, binding, configOptions) {
   const timelineOptions: TIMELINE_OPTIONS = {}
+
   const callbacks = prepareCallbacks(binding)
 
+  // Prepare ScrollTrigger if .whenVisible. modifier is present
+  // You can overwrite scrollTrigger Props in the value of the directive
+  // .once.
   const once = binding.modifiers.call ?? binding.modifiers.once
-  const oneshot = binding.modifiers.oneshot
-
-  // Prevent using both modifiers together
-  if (once && oneshot) {
-    console.warn('Cannot use .once and .oneshot together. Defaulting to .oneshot')
-  }
-
-  const scroller = configOptions?.scroller
+  const scroller
+    = configOptions?.scroller
     || binding.value?.scroller
     || binding.value?.[0]?.scroller
     || binding.value?.[1]?.scroller
     || undefined
-  const scrub = binding.value?.scrub
+  const scrub
+    = binding.value?.scrub
     ?? binding.value?.[1]?.scrub
-    ?? ((once || oneshot) ? false : undefined)
+    ?? (once == true ? false : undefined)
     ?? true
   const markers = binding.modifiers.markers
-
   if (binding.modifiers.whenVisible) {
     timelineOptions.scrollTrigger = {
       trigger: el,
@@ -177,9 +175,11 @@ function prepareTimeline(el, binding, configOptions) {
       scrub,
       ...callbacks,
       markers,
-      toggleActions: (once && !oneshot) ? 'play none none reverse'
-        : oneshot ? 'play none none none'
-          : undefined,
+      toggleActions: binding.modifiers.once
+        ? binding.modifiers.reversible
+          ? 'play none none reverse'
+          : 'play none none none'
+        : undefined,
     }
   }
 


### PR DESCRIPTION
I felt like the behaviour from the previous version was kinda useful so added I oneshot, it would trigger the animation only once it won't play again when scrolling out/in of view again. 

- Improved formatting in playground.vue for better readability.
- Refactored plugin.ts to ensure proper handling of `.once` and `.oneshot` modifiers, including a warning when both are used together.
- General code cleanup and formatting adjustments across multiple files for consistency.