### PR TITLE
feat: GSAPTransition to include group, stagger and delay props.

### DIFF
--- a/docs/content/2.usage/7.v-if.md
+++ b/docs/content/2.usage/7.v-if.md
@@ -22,14 +22,56 @@ doesnt need to be specified.
 </GSAPTransition>
 ```
 
+## Multiple elements
+
+In addition to the `<Transition>` component, Vue provides a `<TransitionGroup>`
+for transitioning multiple elements. Mostly this is done with `v-for` to show
+the appearance of a list of items.
+
+We utilise Vue's default group component by using the `group` flag on
+`<GSAPTransition>`.
+
+```vue
+<GSAPTransition group>
+  <li 
+    v-if="someProp" 
+    v-for="item in items"
+  >
+    {{ item.name }}
+  </li>
+</GSAPTransition>
+```
+
+Visually transitioning multiple elements is best done with a slight `stagger`.
+
+To enable a stagger, `<GSAPTransition>` has to have access to the element's
+index, which is done using `:data-index="idx"` on the transitioning elements.
+
+There is a default value of `0.1s` for the stagger, which can be configured.
+
+```vue
+<GSAPTransition group :stagger="0.15">
+  <li 
+    v-if="someProp" 
+    v-for="(item, idx) in items"
+    :data-index="idx"
+  >
+    {{ item.name }}
+  </li>
+</GSAPTransition>
+```
+
 ## Properties
 
-| Prop     | Type                              | Description                                                                    |
-| -------- | --------------------------------- | ------------------------------------------------------------------------------ |
-| hidden   | `GSAPTweenVars`                   | State of the toggled element when hidden                                       |
-| duration | `number`, default: `0.5`          | The duration of the animation in seconds                                       |
-| appear   | `boolean`, default: `false`       | Wether or not to run the enter-animation on initial load                       |
-| ease     | `string`, default: `power1.inOut` | The ease of the animation. Can be overriden by the `ease` modifier in `hidden` |
+| Prop     | Type                              | Description                                                                                                                             |
+| -------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| hidden   | `GSAPTweenVars`                   | State of the toggled element when hidden                                                                                                |
+| duration | `number`, default: `0.5`          | The duration of the animation in seconds                                                                                                |
+| appear   | `boolean`, default: `false`       | Wether or not to run the enter-animation on initial load                                                                                |
+| ease     | `string`, default: `power1.inOut` | The ease of the animation. Can be overriden by the `ease` modifier in `hidden`                                                          |
+| delay    | `number`, default: `0`            | Initial delay of the transition animation in seconds                                                                                    |
+| group    | `boolean`, default: `false`       | Wether or not the transition applies to multiple elements. Most of the times paired with `v-if`                                         |
+| stagger  | `number`, default: `0.1`          | Delay the appearance of each next element when using `group`. For this to work you also have to put `:data-index="idx"` on the element. |
 
 ## Full Example
 
@@ -37,6 +79,7 @@ doesnt need to be specified.
 <GSAPTransition
   :hidden="{ x: -32 }"
   :duration="1"
+  :delay="0.75"
   :appear="true"
   ease="bounce.out"
 >

--- a/src/runtime/components/GSAPTransition.vue
+++ b/src/runtime/components/GSAPTransition.vue
@@ -32,6 +32,7 @@ const props = withDefaults(
     duration: 0.5,
     appear: false,
     ease: 'power1.inOut',
+    stagger: 0.1,
   },
 )
 

--- a/src/runtime/components/GSAPTransition.vue
+++ b/src/runtime/components/GSAPTransition.vue
@@ -1,5 +1,6 @@
 <template>
-  <Transition
+  <component
+    :is="group ? TransitionGroup : Transition"
     ref="slotRef"
     :duration="duration * 1000"
     :appear="appear"
@@ -8,18 +9,24 @@
     @enter="onEnter"
   >
     <slot />
-  </Transition>
+  </component>
 </template>
 
 <script setup lang="ts">
+import { Transition, TransitionGroup } from 'vue'
 import { useGSAP } from '../plugin'
 import { computed } from '#imports'
+
+type El = Element & { dataset: { index: number } }
 
 const props = withDefaults(
   defineProps<{
     hidden?: any
     duration?: number // seconds
+    stagger?: number // seconds
+    delay?: number // seconds
     appear?: boolean
+    group?: boolean
     ease?: string
   }>(),
   {
@@ -41,17 +48,19 @@ onMounted(() => {
   if (props.appear) useGSAP().set(slotRef.value, hidden.value)
 })
 
-const onEnter = (element: Element, done: () => void) => {
+const onEnter = (element: El, done: () => void) => {
   useGSAP().from(element, {
     ...hidden.value,
+    delay: (props.delay || 0) + element.dataset.index * (props.stagger || 0),
     duration: props.duration,
     onComplete: done,
   })
 }
 
-const onLeave = (element: Element, done: () => void) => {
+const onLeave = (element: El, done: () => void) => {
   useGSAP().to(element, {
     ...hidden.value,
+    delay: (props.delay || 0) + element.dataset.index * (props.stagger || 0),
     duration: props.duration,
     onComplete: done,
   })

--- a/src/runtime/components/GSAPTransition.vue
+++ b/src/runtime/components/GSAPTransition.vue
@@ -13,6 +13,7 @@
 
 <script setup lang="ts">
 import { useGSAP } from '../plugin'
+import { computed } from '#imports'
 
 const props = withDefaults(
   defineProps<{

--- a/src/runtime/components/GSAPTransition.vue
+++ b/src/runtime/components/GSAPTransition.vue
@@ -4,7 +4,6 @@
     ref="slotRef"
     :duration="duration * 1000"
     :appear="appear"
-    :ease="ease"
     @leave="onLeave"
     @enter="onEnter"
   >


### PR DESCRIPTION
First I fixed an error in GSAPTransition that I was getting on the newest version for `computed not found/defined`.

Then I had a vue warning for passing `ease` prop to <Transition>:
```
[Vue warn]: Extraneous non-props attributes (ease) were passed to component but could not be automatically inherited because component renders fragment or text or teleport root nodes.
  at <TransitionGroup ref="slotRef" duration=250 appear=false  ... >
```

 so I removed passing of the easing prop.

And most importantly I updated `<GSAPTransition>` to include transitioning of multiple elements, mostly done with v-for. My use case was showing header links on load, but I have lots of other places to show list items.

By passing a `group` flag to `<GSAPTransition>`, I utilise vue's native `<TransitionGroup>` component for that purpose. I added a `stagger` prop for delaying each next elements appearance by a small amount. To use the stagger, the developer needs to add `:data-index="idx"` to his element as stated in vue's docs: https://vuejs.org/guide/built-ins/transition-group#staggering-list-transitions

Finally I had a need to delay a second list's appearance so I added a `delay` prop as well. I updated the for `Using with v-if`.

I think these features will be useful for all, but let me know your thoughts and feedback on code and/or docs changes.

Cheers,
Harry