### PR TITLE
fix: Add all missing imports from GSAPTransition

### DIFF
--- a/src/runtime/components/GSAPTransition.vue
+++ b/src/runtime/components/GSAPTransition.vue
@@ -12,9 +12,8 @@
 </template>
 
 <script setup lang="ts">
-import { Transition, TransitionGroup } from 'vue'
+import { onMounted, ref, computed, Transition, TransitionGroup } from 'vue'
 import { useGSAP } from '../plugin'
-import { computed } from '#imports'
 
 type El = Element & { dataset: { index: number } }
 


### PR DESCRIPTION
computed was not the only thing crashing, so I added all missing imports