### PR TITLE
feat: expose ScrollTrigger and globalTimelines via composables

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,10 @@
 {
-  "eslint.experimental.useFlatConfig": true
+  "eslint.useFlatConfig": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true
+  },
+  "editor.formatOnSave": false,
+  "eslint.validate": ["javascript", "typescript", "vue"],
+  "eslint.format.enable": true,
+  "prettier.enable": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "eslint.useFlatConfig": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll": true
+    "source.fixAll": "explicit"
   },
   "editor.formatOnSave": false,
   "eslint.validate": ["javascript", "typescript", "vue"],

--- a/docs/content/2.usage/6.composable.md
+++ b/docs/content/2.usage/6.composable.md
@@ -16,6 +16,27 @@ onMounted(() => {
 </script>
 ```
 
+In addition to using gsap programmatically, you can also use the ScrollTrigger from `useScrollTrigger()` and access globalTimelines via `useGlobalTimelines()`.
+
+```vue
+<script setup>
+const ScrollTrigger = useScrollTrigger();
+
+// It's useful to refresh the positions of scroll trigger elements,
+// when the layout changes heights and/or other elements expand, etc.
+useResizeObserver(layoutRef, async () => {
+  ScrollTrigger.refresh();
+});
+</script>
+
+```vue
+<script setup>
+const globalTimelines = useGlobalTimelines();
+
+// If you really want fine grain control and/or want to debug,
+// this is an access to all timelines from v-gsap-nuxt.
+</script>
+
 ## Disabling composable
 
 If you are experiencing issues due to other already existing imports of gsap, you can disable the auto-import of the composable in `nuxt.config.ts` via the `composable: ` property [See more](/installation/configuration)

--- a/src/module.ts
+++ b/src/module.ts
@@ -44,6 +44,16 @@ export default defineNuxtModule<ModuleOptions>({
         as: 'useGSAP',
         from: resolver.resolve('runtime/plugin'), // load composable from plugin
       })
+      addImports({
+        name: 'useScrollTrigger',
+        as: 'useScrollTrigger',
+        from: resolver.resolve('runtime/plugin'),
+      })
+      addImports({
+        name: 'useGlobalTimelines',
+        as: 'useGlobalTimelines',
+        from: resolver.resolve('runtime/plugin'),
+      })
     }
 
     addComponent({

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -531,3 +531,11 @@ function getValueFromModifier(binding, term: string) {
 export const useGSAP = (): typeof gsap => {
   return gsap
 }
+
+export const useScrollTrigger = () => {
+  return ScrollTrigger
+}
+
+export const useGlobalTimelines = () => {
+  return globalTimelines
+}

--- a/src/runtime/vue.ts
+++ b/src/runtime/vue.ts
@@ -1,5 +1,10 @@
 import gsap from 'gsap'
-import { vGsapDirective } from './plugin'
+import {
+  vGsapDirective,
+  useGSAP,
+  useScrollTrigger,
+  useGlobalTimelines,
+} from './plugin'
 
 export const vGsapVue = (configOptions?) => {
   return vGsapDirective(
@@ -9,3 +14,6 @@ export const vGsapVue = (configOptions?) => {
     null,
   )
 }
+
+// Export composables for Vue-only usage
+export { useGSAP, useScrollTrigger, useGlobalTimelines }


### PR DESCRIPTION
Hey Lukas,

In my current project (and most others) I frequently have to refresh ScrollTrigger from time to time and mostly when _navigating to other pages_.

My current use case is that my Footer component exists in the layout and does not 'change' on page navigations, so its reveal animations are not displayed properly on pages with different heights.

If I do ScrollTrigger.refresh() on slug nav they get nicely refreshed. However if I import via 'gsap/ScrollTrigger' it doesnt work as it is not the same instance.


For this reason I create a composable that exposes v-gsap-nuxt's ScrollTrigger and all is good. 

While I was at it, I exposed globalTimelines if they might be needed, but have no use case for now.

Final thought - my prettier was formatting your files wrong, so I added some stuff in .vscode/settings.json - let me know if they are okay or I need to remove em.

Cheers