### PR TITLE
fix(ssr): hide elements with from.opacity:0 to prevent FOUC

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -559,7 +559,10 @@ function prepareTimeline(el, binding, configOptions, skipSplitText = false) {
     if (stagger !== false) fromProps.stagger = stagger
     timeline.from(animationTarget, fromProps)
 
-    if (binding.modifiers.fromInvisible) {
+    // gsap.from() infers the to-state from current computed style — when
+    // the SSR hider in vgsap.css pins opacity:0 the tween runs 0->0. Force
+    // opacity:1 explicitly whenever the from-state is 0.
+    if (binding.modifiers.fromInvisible || fromProps.opacity === 0) {
       const toProps: any = { opacity: 1, duration: binding.value.duration || 0.5 }
       if (stagger !== false) toProps.stagger = stagger
       timeline.to(animationTarget, toProps, '<')

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -45,11 +45,18 @@ export const vGsapDirective = (
 ) => ({
   getSSRProps: (binding) => {
     binding = loadPreset(binding, configOptions)
+    const m = binding.modifiers
+    const v = binding.value
+    const fromValue = m.fromTo ? v?.[0] : v
+    const fromOpacityZero
+      = (m.from || m.fromTo)
+      && fromValue && typeof fromValue === 'object'
+      && fromValue.opacity === 0
 
     return {
-      'data-vgsap-from-invisible': binding.modifiers.fromInvisible,
-      'data-vgsap-stagger': binding.modifiers.stagger,
-      'data-vgsap-mask': binding.modifiers.mask,
+      'data-vgsap-from-invisible': m.fromInvisible || fromOpacityZero || undefined,
+      'data-vgsap-stagger': m.stagger,
+      'data-vgsap-mask': m.mask,
     }
   },
 


### PR DESCRIPTION
## Summary
- `getSSRProps` only emits `data-vgsap-from-invisible` when the `.fromInvisible` modifier is set, missing the equivalent case where `.from` / `.fromTo` declares
`opacity: 0` directly in its vars
- Result: elements render fully visible in SSR HTML and then flash to invisible once `beforeMount` runs the GSAP tween — brief FOUC
- The fix detects `opacity: 0` in the from-side vars (index 0 for `.fromTo`, the value itself for `.from`) and applies the same SSR hider attribute the modifier
triggers
- `.to` bindings with `opacity: 0` are intentionally excluded — hiding those pre-hydration would cause the inverse flash
